### PR TITLE
Headless capybara-webkit: needs chromedriver installed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ end
 
 group :test do
   gem 'capybara', '~> 2.4'
+  gem 'capybara-webkit', '~> 1.12'
   gem 'database_cleaner', '~> 1.4'
   gem 'rspec-collection_matchers', '~> 1.1'
   gem 'shoulda-matchers', '~> 2.8'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,11 +41,25 @@ Dir[MessageTrain::Engine.root.join('spec/support/**/**/*.rb')]
 ActiveRecord::Migrator.migrations_paths = 'spec/dummy/db/migrate'
 ActiveRecord::Migration.maintain_test_schema!
 
-Capybara.register_driver :chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome)
+# Capybara.register_driver :chrome do |app|
+#   Capybara::Selenium::Driver.new(app, browser: :chrome)
+# end
+
+# Capybara.javascript_driver = :chrome
+
+Capybara.register_driver :selenium do |app|
+  client = Selenium::WebDriver::Remote::Http::Default.new
+  client.timeout = 3
+  Capybara::Selenium::Driver.new(app, :browser => :chrome, :http_client => client)
 end
 
-Capybara.javascript_driver = :chrome
+Capybara.javascript_driver =  :webkit
+
+Capybara::Webkit.configure do |config|
+  config.block_unknown_urls
+  # config.allow_url("important-api.com/GiveMeJSON")
+  config.ignore_ssl_errors
+end
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
Speeds up testing by around 10%; also less distracting.